### PR TITLE
[ETCM-5212] Include incoming transactions when they become stable in the main chain

### DIFF
--- a/src/kube/substrate-poc/environments/alice/alice.yaml
+++ b/src/kube/substrate-poc/environments/alice/alice.yaml
@@ -175,7 +175,7 @@ spec:
           mountPath: /var/lib/postgresql/data
     - name: bridge-backend
       image: 689191102645.dkr.ecr.eu-central-1.amazonaws.com/bridge-backend:0.10.0
-      command: ["/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000"]
+      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000", "-Dmainchain.security-parameter=432" ]
       imagePullPolicy: IfNotPresent
       resources:
         limits:
@@ -274,7 +274,7 @@ spec:
         - containerPort: 9933
           name: rpc-port
         - containerPort: 9615
-          name: prometheus 
+          name: prometheus
       volumeMounts:
         - name: substrate-node-data
           mountPath: /data
@@ -294,7 +294,7 @@ spec:
         - name: VECTOR_SELF_NODE_NAME
           valueFrom:
             fieldRef:
-              fieldPath: spec.nodeName 
+              fieldPath: spec.nodeName
       ports:
         - containerPort: 8686
         - containerPort: 9182

--- a/src/kube/substrate-poc/environments/bob/bob.yaml
+++ b/src/kube/substrate-poc/environments/bob/bob.yaml
@@ -175,7 +175,7 @@ spec:
           mountPath: /var/lib/postgresql/data
     - name: bridge-backend
       image: 689191102645.dkr.ecr.eu-central-1.amazonaws.com/bridge-backend:0.10.0
-      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000" ]
+      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000", "-Dmainchain.security-parameter=432" ]
       imagePullPolicy: IfNotPresent
       resources:
         limits:

--- a/src/kube/substrate-poc/environments/charlie/charlie.yaml
+++ b/src/kube/substrate-poc/environments/charlie/charlie.yaml
@@ -175,7 +175,7 @@ spec:
           mountPath: /var/lib/postgresql/data
     - name: bridge-backend
       image: 689191102645.dkr.ecr.eu-central-1.amazonaws.com/bridge-backend:0.10.0
-      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000" ]
+      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000", "-Dmainchain.security-parameter=432" ]
       imagePullPolicy: IfNotPresent
       resources:
         limits:

--- a/src/kube/substrate-poc/environments/dave/dave.yaml
+++ b/src/kube/substrate-poc/environments/dave/dave.yaml
@@ -175,7 +175,7 @@ spec:
           mountPath: /var/lib/postgresql/data
     - name: bridge-backend
       image: 689191102645.dkr.ecr.eu-central-1.amazonaws.com/bridge-backend:0.10.0
-      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000" ]
+      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000", "-Dmainchain.security-parameter=432" ]
       imagePullPolicy: IfNotPresent
       resources:
         limits:
@@ -274,7 +274,7 @@ spec:
         - containerPort: 9933
           name: rpc-port
         - containerPort: 9615
-          name: prometheus 
+          name: prometheus
       volumeMounts:
         - name: substrate-node-data
           mountPath: /data

--- a/src/kube/substrate-poc/environments/eve/eve.yaml
+++ b/src/kube/substrate-poc/environments/eve/eve.yaml
@@ -175,7 +175,7 @@ spec:
           mountPath: /var/lib/postgresql/data
     - name: bridge-backend
       image: 689191102645.dkr.ecr.eu-central-1.amazonaws.com/bridge-backend:0.10.0
-      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000" ]
+      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000", "-Dmainchain.security-parameter=432" ]
       imagePullPolicy: IfNotPresent
       resources:
         limits:

--- a/src/kube/substrate-poc/environments/ferdie/ferdie.yaml
+++ b/src/kube/substrate-poc/environments/ferdie/ferdie.yaml
@@ -175,7 +175,7 @@ spec:
           mountPath: /var/lib/postgresql/data
     - name: bridge-backend
       image: 689191102645.dkr.ecr.eu-central-1.amazonaws.com/bridge-backend:0.10.0
-      command: ["/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000"]
+      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000", "-Dmainchain.security-parameter=432" ]
       imagePullPolicy: IfNotPresent
       resources:
         limits:

--- a/src/kube/substrate-poc/environments/greg/greg.yaml
+++ b/src/kube/substrate-poc/environments/greg/greg.yaml
@@ -175,7 +175,7 @@ spec:
           mountPath: /var/lib/postgresql/data
     - name: bridge-backend
       image: 689191102645.dkr.ecr.eu-central-1.amazonaws.com/bridge-backend:0.10.0
-      command: ["/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000"]
+      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000", "-Dmainchain.security-parameter=432" ]
       imagePullPolicy: IfNotPresent
       resources:
         limits:

--- a/src/kube/substrate-poc/environments/substrate-node-stack-chart/templates/main.yaml
+++ b/src/kube/substrate-poc/environments/substrate-node-stack-chart/templates/main.yaml
@@ -102,7 +102,7 @@ spec:
           mountPath: /var/lib/postgresql/data
     - name: bridge-backend
       image: 689191102645.dkr.ecr.eu-central-1.amazonaws.com/bridge-backend:0.10.0
-      command: ["/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000"]
+      command: [ "/opt/docker/bin/bridge-backend", "-Dmainchain.epoch-duration=86400000", "-Dmainchain.security-parameter=432" ]
       imagePullPolicy: IfNotPresent
       resources:
         limits:


### PR DESCRIPTION
Without this config override, we use value from [bridge-backend reference.conf](https://github.com/input-output-hk/sidechains-bridge-backend/blob/02cca5815998ea4fa36cdf973823423725a20f0c/service/src/main/resources/reference.conf#L41) that is set for takao.
Updated value matches shelley-genesis securityParam of Preview.